### PR TITLE
Refactor Adaptive Delegate Handling #4

### DIFF
--- a/Sources/Toolbox/Coordinators/NavigationCoordinator.swift
+++ b/Sources/Toolbox/Coordinators/NavigationCoordinator.swift
@@ -29,6 +29,7 @@ open class NavigationCoordinator: Coordinator {
             if let parentCoordinator = parentCoordinator as? NavigationCoordinator, pushedViewControllers.isEmpty {
                 parentCoordinator.removeChild(self)
                 navigationController.delegate = parentCoordinator
+                navigationController.presentationController?.delegate = parentCoordinator
             }
         }
     }
@@ -63,6 +64,7 @@ open class NavigationCoordinator: Coordinator {
         if let navigationCoordinator = coordinator as? NavigationCoordinator {
             navigationController.delegate = navigationCoordinator // hand delegate to last coordinator
         }
+        navigationController.presentationController?.delegate = coordinator
     }
     
     public func popCoordinator(animated: Bool) {


### PR DESCRIPTION
Applied the same approach as the NavigationCoordinator handles the delegate:

- the coordinator holds the delegate for the RootViewController
- when the delegate calls  `presentationControllerDidDismiss ` the child removes itself from the parent coordinator. 

Additional to that the navigation coordinator now handles the delegate in a more meaningful way by handing over the delegate when pushing a child coordinator. 

As the coordinator itself is now the delegate, Subclasses can now implement the functions of the `UIAdaptivePresentationControllerDelegate` more easily. 