### PR TITLE
Improved UserDefault propertyWrapper

### DIFF
--- a/Sources/Toolbox/Utilities/UserDefaults.swift
+++ b/Sources/Toolbox/Utilities/UserDefaults.swift
@@ -1,21 +1,69 @@
 import Foundation
+// https://swiftbysundell.com/articles/property-wrappers-in-swift/
+// Since our property wrapper's Value type isn't optional, but
+// can still contain nil values, we'll have to introduce this
+// protocol to enable us to cast any assigned value into a type
+// that we can compare against nil:
+private protocol AnyOptional {
+    var isNil: Bool { get }
+}
 
-@propertyWrapper
-public struct UserDefault<T> {
+extension Optional: AnyOptional {
+    var isNil: Bool { self == nil }
+}
+
+@propertyWrapper public struct UserDefault<Value> {
     public let key: String
-    let defaultValue: T
-
-    init(_ key: String, defaultValue: T) {
+    public let defaultValue: Value
+    public var storage: UserDefaults = .standard
+    
+    public var wrappedValue: Value {
+        set {
+            if let anyOptional = newValue as? AnyOptional, anyOptional.isNil {
+                storage.removeObject(forKey: key)
+            } else {
+                storage.set(newValue, forKey: key)
+            }
+        } get {
+            return getValue()
+        }
+    }
+    
+    public init(key: String, defaultValue: Value, storage: UserDefaults = .standard) {
         self.key = key
         self.defaultValue = defaultValue
+        self.storage = storage
     }
+}
 
-    public var wrappedValue: T {
-        get {
-            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+public extension UserDefault where Value: ExpressibleByNilLiteral {
+    init(key: String, storage: UserDefaults = .standard) {
+        self.init(key: key, defaultValue: nil, storage: storage)
+    }
+}
+
+private extension UserDefault {
+    /// UserDefaults coerces certain types, in order to keep that behaviour, the data retrieval has to be performed with the typed functions
+    private func getValue() -> Value {
+        
+        let type = nestedType(of: Value.self)
+        
+        let value: Value?
+    
+        if type == Bool.self {
+            value = storage.bool(forKey: key) as? Value
+        } else if type == Int.self {
+            value = storage.integer(forKey: key) as? Value
+        } else if type == Float.self {
+            value = storage.float(forKey: key) as? Value
+        } else if type == Double.self {
+            value = storage.double(forKey: key) as? Value
+        } else if type == URL.self {
+            value = storage.url(forKey: key) as? Value
+        } else {
+            value = storage.value(forKey: key) as? Value
         }
-        set {
-            UserDefaults.standard.set(newValue, forKey: key)
-        }
+        
+        return value ?? defaultValue
     }
 }

--- a/Tests/ToolboxTests/UserDefaultTests.swift
+++ b/Tests/ToolboxTests/UserDefaultTests.swift
@@ -1,0 +1,81 @@
+
+import XCTest
+import Toolbox
+
+class UserDefaultTests: XCTestCase {
+        
+    @UserDefault(key: "someBool", defaultValue: false)
+    var someBool: Bool
+    
+    @UserDefault(key: "someInt", defaultValue: 0)
+    var someInt: Int
+    
+    @UserDefault(key: "someDouble", defaultValue: 0.0)
+    var someDouble: Double
+    
+    @UserDefault(key: "someFloat", defaultValue: 0.0)
+    var someFloat: Float
+    
+    @UserDefault(key: "someURL", defaultValue: URL(fileURLWithPath: "/"))
+    var someURL: URL
+    
+    @UserDefault(key: "someDictionary")
+    var someDictionary: [String: Any]?
+    
+    
+    func testReadCoercedBool() {
+        UserDefaults.standard.setValue(1, forKey: "someBool")
+        XCTAssertEqual(someBool, true)
+                
+        UserDefaults.standard.setValue("true", forKey: "someBool")
+        XCTAssertEqual(someBool, true)
+    }
+    
+    func testReadCoercedInt() {
+        UserDefaults.standard.setValue(true, forKey: "someInt")
+        XCTAssertEqual(someInt, 1)
+                
+        UserDefaults.standard.setValue("1", forKey: "someInt")
+        XCTAssertEqual(someInt, 1)
+    }
+    
+    func testReadCoercedDouble() {
+        UserDefaults.standard.setValue(true, forKey: "someDouble")
+        XCTAssertEqual(someDouble, 1.0)
+                
+        UserDefaults.standard.setValue("1.1", forKey: "someDouble")
+        XCTAssertEqual(someDouble, 1.1)
+    }
+    
+    func testReadCoercedFloat() {
+        UserDefaults.standard.setValue(true, forKey: "someFloat")
+        XCTAssertEqual(someFloat, 1.0)
+                
+        UserDefaults.standard.setValue("1.1", forKey: "someFloat")
+        XCTAssertEqual(someFloat, 1.1)
+    }
+    
+    func testReadCoercedURL() {
+        let stringURL = "file:///Users/swift/Desktop"
+        UserDefaults.standard.setValue(stringURL, forKey: "someURL")
+        XCTAssertEqual(someURL, URL(fileURLWithPath: stringURL))
+    }
+    
+    func testWriteOptionalDictionary() {
+        someDictionary = ["a": 1, "b": "2"]
+        XCTAssertNotNil(UserDefaults.standard.object(forKey: "someDictionary"))
+        
+        someDictionary = nil
+        XCTAssertNil(UserDefaults.standard.object(forKey: "someDictionary"))
+    }
+    
+    
+    static var allTests = [
+        ("testReadCoercedBool", testReadCoercedBool),
+        ("testReadCoercedInt", testReadCoercedInt),
+        ("testReadCoercedDouble", testReadCoercedDouble),
+        ("testReadCoercedFloat", testReadCoercedFloat),
+        ("testReadCoercedURL", testReadCoercedURL),
+        ("testWriteOptionalDictionary", testWriteOptionalDictionary),
+    ]
+}

--- a/Tests/ToolboxTests/XCTestManifests.swift
+++ b/Tests/ToolboxTests/XCTestManifests.swift
@@ -4,6 +4,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ToolboxTests.allTests),
+        testCase(UserDefaults.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
* Added support for UserDefaults "type coercing" e.g. string "1" can be read from UserDefaults as 1 Int
* UserDefault can now be used with optional types and will also get correctly removed if nil
* Also added nested optional handling