### PR TITLE
Fix default init of Navigation- and TabBarCoordinator + add unit tests

### DIFF
--- a/Sources/Toolbox/Coordinators/NavigationCoordinator.swift
+++ b/Sources/Toolbox/Coordinators/NavigationCoordinator.swift
@@ -15,7 +15,7 @@ open class NavigationCoordinator: Coordinator {
         self.pushedViewControllers = WeakArray([])
         self.navigationController = navigationController ?? UINavigationController()
         
-        super.init(rootViewController: navigationController)
+        super.init(rootViewController: self.navigationController)
         
         if self.navigationController.delegate == nil {
             self.navigationController.delegate = self

--- a/Sources/Toolbox/Coordinators/TabBarCoordinator.swift
+++ b/Sources/Toolbox/Coordinators/TabBarCoordinator.swift
@@ -7,7 +7,7 @@ open class TabBarCoordinator: Coordinator {
     
     public init(tabBarController: UITabBarController? = nil) {
         self.tabBarController = tabBarController ?? UITabBarController()
-        super.init(rootViewController: tabBarController!)
+        super.init(rootViewController: self.tabBarController)
         self.tabBarController.delegate = self
     }
     

--- a/Tests/ToolboxTests/NavigationCoordinatorTests.swift
+++ b/Tests/ToolboxTests/NavigationCoordinatorTests.swift
@@ -1,0 +1,45 @@
+@testable import Toolbox
+import XCTest
+
+final class NavigationCoordinatorTests: XCTestCase {
+
+    func testNavigationCoordinatorInitialization() async throws {
+        let expectation = XCTestExpectation(description: "NavigationCoordinator initialization")
+        
+        // Switch to the main actor context.
+        await MainActor.run {
+            let navCoordinator = NavigationCoordinator()
+            
+            // Test your coordinator instance here, e.g.:
+            XCTAssertNotNil(navCoordinator)
+            
+            // Fulfill the expectation when the test is complete.
+            expectation.fulfill()
+        }
+        
+        // Wait for the expectation to be fulfilled.
+        wait(for: [expectation], timeout: 10)
+    }
+    
+    func testNavigationCoordinatorRootIsUINavigationController() async throws {
+        let expectation = XCTestExpectation(description: "NavigationCoordinator initialization")
+        
+        // Switch to the main actor context.
+        await MainActor.run {
+            let navCoordinator = NavigationCoordinator()
+            
+            // Test your coordinator instance here, e.g.:
+            XCTAssertNotNil(navCoordinator)
+            
+            // Check if the rootViewController is of type UITabBarController
+            XCTAssertTrue(navCoordinator.rootViewController is UINavigationController)
+            
+            // Fulfill the expectation when the test is complete.
+            expectation.fulfill()
+        }
+        
+        // Wait for the expectation to be fulfilled.
+        wait(for: [expectation], timeout: 10)
+    }
+
+}

--- a/Tests/ToolboxTests/TabBarCoordinatorTests.swift
+++ b/Tests/ToolboxTests/TabBarCoordinatorTests.swift
@@ -1,0 +1,44 @@
+@testable import Toolbox
+import XCTest
+
+final class TabBarCoordinatorTests: XCTestCase {
+
+    func testTabBarCoordinatorInitialization() async throws {
+        let expectation = XCTestExpectation(description: "TabBarCoordinator initialization")
+        
+        // Switch to the main actor context.
+        await MainActor.run {
+            let mainCoordinator = TabBarCoordinator()
+            
+            // Test your coordinator instance here, e.g.:
+            XCTAssertNotNil(mainCoordinator)
+            
+            // Fulfill the expectation when the test is complete.
+            expectation.fulfill()
+        }
+        
+        // Wait for the expectation to be fulfilled.
+        wait(for: [expectation], timeout: 10)
+    }
+    
+    func testTabBarCoordinatorRootIsUITabBarController() async throws {
+        let expectation = XCTestExpectation(description: "TabBarCoordinator initialization")
+        
+        // Switch to the main actor context.
+        await MainActor.run {
+            let tabBarCoordinator = TabBarCoordinator()
+            
+            // Test your coordinator instance here, e.g.:
+            XCTAssertNotNil(tabBarCoordinator)
+            
+            // Check if the rootViewController is of type UITabBarController
+            XCTAssertTrue(tabBarCoordinator.rootViewController is UITabBarController)
+            
+            // Fulfill the expectation when the test is complete.
+            expectation.fulfill()
+        }
+        
+        // Wait for the expectation to be fulfilled.
+        wait(for: [expectation], timeout: 10)
+    }
+}


### PR DESCRIPTION
Currently the NavigationCoordinator and TabBarCoordinator using not the default Controller, if the User had not add one in the init function. This leads to a default UIViewController as rootViewController for both.

Additionally the code try to force unwrap the optional UITabBarController from the init function, which can be nil and is also nil on the ios-starter from your repository. This leads to a crash and is actually also not necessary, if we use the correct one like described above.

I added also unit tests for both cases, which failed before the fixes and runs successfully afterwards.